### PR TITLE
Enable the polling feature on catalogsource

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -514,7 +514,13 @@ func (o *Operator) syncRegistryServer(logger *logrus.Entry, in *v1alpha1.Catalog
 	if healthy && in.Status.RegistryServiceStatus != nil {
 		logger.Debug("registry state good")
 		continueSync = true
-		return
+		// Check if registryService is ready for polling update
+		if out.ReadyToUpdate() {
+			// Set the lastUpdateTime to now
+			out.SetLastUpdateTime()
+		} else {
+			return
+		}
 	}
 
 	// Registry pod hasn't been created or hasn't been updated since the last configmap update, recreate it


### PR DESCRIPTION
1. Add new field `LastUpdateTime` to `CatalogSource` status to
record the last time the `CatalogSource` has been checked to ensure
the image is up-to-date.
2. Add new two new funcs to `CatalogSource` to:
	- To set `LastUpdateTime`
	- To check if it is time to update
3. Adjust to `syncRegistryServer` flow to enable the polling feature
4. Clean up grpc.go code

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
